### PR TITLE
feat: Initialize audio module refactor for Clean Architecture

### DIFF
--- a/src/domain/entities/AudioProduct.js
+++ b/src/domain/entities/AudioProduct.js
@@ -1,0 +1,14 @@
+class AudioProduct {
+  constructor(src) {
+    if (!src) {
+      throw new Error("Subclasses of AudioProduct must provide a 'src'.");
+    }
+    this.srcBase = src;
+  }
+
+  create(src = this.srcBase, loop = true, volume = 1) {
+    throw new Error("Method 'create()' must be implemented in subclasses.");
+  }
+}
+
+export default AudioProduct;

--- a/src/domain/factories/AudioFactory.js
+++ b/src/domain/factories/AudioFactory.js
@@ -1,0 +1,7 @@
+class AudioFactory {
+  create(src, loop, volume) {
+    throw new Error("Method 'create()' must be implemented in subclasses to create audio products.");
+  }
+}
+
+export default AudioFactory;

--- a/src/infrastructure/audio/factories/HowlFactory.js
+++ b/src/infrastructure/audio/factories/HowlFactory.js
@@ -1,0 +1,12 @@
+import AudioFactory from "../../../domain/factories/AudioFactory.js";
+import HowlProduct from "../products/HowlProduct.js";
+
+class HowlFactory extends AudioFactory  {
+  create(src, loop, volume) {
+    const howlProductInstance = new HowlProduct(src, loop, volume);
+    const backgroundMusic = howlProductInstance.create();
+    return backgroundMusic;
+  }
+}
+
+export { HowlFactory };

--- a/src/infrastructure/audio/products/HowlProduct.js
+++ b/src/infrastructure/audio/products/HowlProduct.js
@@ -1,0 +1,22 @@
+import { Howl } from "howler";
+import AudioProduct from "../../../domain/entities/AudioProduct.js";
+
+class HowlProduct extends AudioProduct {
+    constructor(src, loop = true, volume = 1) {
+        super(src);
+        this.src = src;
+        this.loop = loop;
+        this.volume = volume;
+    }
+
+    create() {
+        this.music = new Howl({
+            src: this.src,
+            loop: this.loop,
+            volume: this.volume,
+        });
+        return this.music;
+    }
+}
+
+export default HowlProduct;

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import * as THREE from "three";
 import { OrbitControls } from "./utils/OrbitControls.js";
 import { DRACOLoader } from "three/addons/loaders/DRACOLoader.js";
 import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { HowlFactory } from "./infrastructure/audio/factories/HowlFactory.js";
 
 import smokeVertexShader from "./shaders/smoke/vertex.glsl";
 import smokeFragmentShader from "./shaders/smoke/fragment.glsl";
@@ -22,11 +23,11 @@ const PIANO_TIMEOUT = 2000;
 const BACKGROUND_MUSIC_VOLUME = 1;
 const FADED_VOLUME = 0;
 
-const backgroundMusic = new Howl({
-  src: ["/audio/music/cosmic_candy.ogg"],
-  loop: true,
-  volume: 1,
-});
+const src = ["/audio/music/cosmic_candy.ogg"];
+const loop = true;
+const volume = 1;
+const useHowl = new HowlFactory(); // No pasas argumentos al constructor
+const backgroundMusic = useHowl.create(src, loop, volume); // Pasas los argumentos a render()
 
 const fadeOutBackgroundMusic = () => {
   if (!isMuted && !isMusicFaded) {


### PR DESCRIPTION
This commit sets up the initial structure for refactoring the audio module
to align with Clean Architecture principles. It includes:

- Creation of the `src/domain/audio/entities` and `src/domain/audio/factories` directories for abstract definitions.
- Creation of the `src/infrastructure/audio/factories` and `src/infrastructure/audio/products` directories for concrete implementations.
- Abstract `AudioProduct` and `AudioFactory` classes to the domain layer.
- Concrete `HowlProduct` and `HowlFactory` classes to the infrastructure layer.
- Updating import paths in relevant files to reflect the new structure.

This commit establishes
the foundational structure for applying the Abstract Factory pattern and
separating concerns according to Clean Architecture.